### PR TITLE
Add toggle for auto load (Closes #4) 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
 import runExtension from "roamjs-components/util/runExtension";
+import type { ExtensionAPI } from "~/types/stats";
+import { AUTO_LOAD_STATS_SETTING } from "~/utils/stats";
 import { toggleStatsDrawer } from "./components/StatsDrawer";
 import { render as renderToast } from "roamjs-components/components/Toast";
 
 const COMMAND_LABEL = "Stats: Toggle Stats Drawer";
+const SETTINGS_TAB_TITLE = "Stats";
+
+const getAutoLoadSettingValue = ({
+  extensionAPI,
+}: {
+  extensionAPI: ExtensionAPI;
+}): unknown => extensionAPI.settings.get(AUTO_LOAD_STATS_SETTING);
+
 export default runExtension(async ({ extensionAPI }) => {
   if (process.env.NODE_ENV === "development") {
     renderToast({
@@ -13,9 +23,25 @@ export default runExtension(async ({ extensionAPI }) => {
     });
   }
 
+  extensionAPI.settings.panel.create({
+    tabTitle: SETTINGS_TAB_TITLE,
+    settings: [
+      {
+        id: AUTO_LOAD_STATS_SETTING,
+        name: "Auto-load stats",
+        description: "Automatically fetch all stats when opening the drawer.",
+        action: { type: "switch" },
+      },
+    ],
+  });
+
+  if (typeof getAutoLoadSettingValue({ extensionAPI }) !== "boolean") {
+    await extensionAPI.settings.set(AUTO_LOAD_STATS_SETTING, true);
+  }
+
   await extensionAPI.ui.commandPalette.addCommand({
     label: COMMAND_LABEL,
-    callback: toggleStatsDrawer,
+    callback: () => toggleStatsDrawer({ extensionAPI }),
   });
 
   return {

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -1,0 +1,33 @@
+import type { OnloadArgs } from "roamjs-components/types/native";
+
+export type ExtensionAPI = OnloadArgs["extensionAPI"];
+
+export type TagName =
+  | "TODO"
+  | "DONE"
+  | "query"
+  | "embed"
+  | "table"
+  | "kanban"
+  | "video"
+  | "roam/js";
+
+export type StatMetricKey =
+  | "pages"
+  | "nonCodeBlocks"
+  | "nonCodeBlockWords"
+  | "nonCodeBlockChars"
+  | "blockquotes"
+  | "blockquotesWords"
+  | "blockquotesChars"
+  | "codeBlocks"
+  | "codeBlockChars"
+  | "interconnections"
+  | "firebaseLinks"
+  | "externalLinks";
+
+export type Stats = Partial<Record<StatMetricKey, number>> & {
+  tagCounts?: Partial<Record<TagName, number>>;
+};
+
+export type LoadingState = Record<string, boolean>;

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,40 @@
+import type { ExtensionAPI, TagName } from "~/types/stats";
+
+export const TAGS: readonly TagName[] = [
+  "TODO",
+  "DONE",
+  "query",
+  "embed",
+  "table",
+  "kanban",
+  "video",
+  "roam/js",
+];
+
+export const AUTO_LOAD_STATS_SETTING = "auto-load-stats";
+
+export const formatInt = (n: number): string => n.toLocaleString();
+
+export const getLoadingKeyForTag = (tag: TagName): string => `tag:${tag}`;
+
+export const runAfterNextPaint = ({
+  callback,
+}: {
+  callback: () => void;
+}): void => {
+  if (typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(() => callback());
+    return;
+  }
+
+  window.setTimeout(() => callback(), 0);
+};
+
+export const getAutoLoadPreference = ({
+  extensionAPI,
+}: {
+  extensionAPI: ExtensionAPI;
+}): boolean => {
+  const value = extensionAPI.settings.get(AUTO_LOAD_STATS_SETTING);
+  return typeof value === "boolean" ? value : true;
+};


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roamjs/stats/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added asynchronous stats loading with per-metric loading states for improved performance
  * Introduced "Auto-load stats" toggle in the new Stats settings tab
  * Added manual "Load all stats" button when auto-load is disabled, with loading indicators for individual metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->